### PR TITLE
Renamed 'FalseElim' to 'void'

### DIFF
--- a/idrislang.sty
+++ b/idrislang.sty
@@ -95,7 +95,7 @@
     % rem, intToMod, modToStr, branch4, branch5, branch6, branch7,
     % merge1, merge2, merge3, treeLookup, treeInsert, delType,
     % treeDelete, treeToList, empty, lookup, insert, delete, fromList,
-    % toList, getWitness, getProof, FalseElim, replace, sym, trans,
+    % toList, getWitness, getProof, void, replace, sym, trans,
     % lazy, par, malloc, Not, id, the, const, fst, snd, flip, cong,
     % boolElim, not, intToBool, boolOp, div, mod, strHead, strTail,
     % strCons, strIndex, reverse, null, getArgs, getEnv, setEnv,


### PR DESCRIPTION
This relates to idris-lang/Idris-dev#1619
