### PR TITLE
corrected Effect.Random sample code on Page 15

### DIFF
--- a/content/simpleeff.tex
+++ b/content/simpleeff.tex
@@ -309,10 +309,10 @@ this, see the \texttt{SYSTEM} effect described in Appendix \ref{sect:appendix}.
 guess : Int -> { [STDIO] } Eff ()
 guess target
     = do putStr "Guess: "
-         case run (parseNumber 100 (trim !getStr)) of
+         case (the (Maybe Int) $ run (parseNumber 100 (trim !getStr))) of
               Nothing => do putStrLn "Invalid input"
                             guess target
-              Just (v ** _) =>
+              Just v  =>
                          case compare v target of
                              LT => do putStrLn "Too low"
                                       guess target


### PR DESCRIPTION
corrected Effect.Random sample code on Page 15

Without this patch, compiling the example has the below error message

*eff> :r
Type checking ./eff.idr
eff.idr:65:7:When elaborating right hand side of guess:
Can't resolve type class Applicative m
Metavariables: Main.guess
